### PR TITLE
fix warnings

### DIFF
--- a/aad/client.bal
+++ b/aad/client.bal
@@ -96,8 +96,7 @@ public isolated client class Client {
                                        returns @display {label: "Stream of User records"} stream<User, error?>|error {
         string path = check createUrl([USERS], queryParams);
         http:Response response = check self.httpClient->get(path);
-
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         UserStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<User, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -172,8 +171,7 @@ public isolated client class Client {
                                         stream<Group, error?>|error {
         string path = check createUrl([GROUPS], queryParams);   
         http:Response response = check self.httpClient->get(path);
-
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         GroupStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<Group, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -225,7 +223,7 @@ public isolated client class Client {
         }
         
         http:Response response = check self.httpClient->get(path);
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         GroupStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<Group, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -255,7 +253,7 @@ public isolated client class Client {
         }
         
         http:Response response = check self.httpClient->get(path);
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         GroupStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<Group, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -306,7 +304,7 @@ public isolated client class Client {
         string path = check createUrl([GROUPS, groupId, MEMBERS], queryParams);   
         http:Response response = check self.httpClient->get(path);
 
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         UserStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<User, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -328,7 +326,7 @@ public isolated client class Client {
         string path = check createUrl([GROUPS, groupId, TRANSITIVE_MEMBERS], queryParams);   
         http:Response response = check self.httpClient->get(path);
 
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         UserStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<User, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -379,7 +377,7 @@ public isolated client class Client {
         string path = check createUrl([GROUPS, groupId, OWNERS], queryParams);   
         http:Response response = check self.httpClient->get(path);
 
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         UserStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<User, error?> finalStream = new (objectInstance);
         return finalStream; 
@@ -416,7 +414,7 @@ public isolated client class Client {
         string path = check createUrl([GROUPS, groupId, PERMISSION_GRANTS]);   
         http:Response response = check self.httpClient->get(path);
 
-        map<json>|string handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         PermissionGrantStream objectInstance = check new (self.config, self.httpClient, path, queryParams);
         stream<PermissionGrant, error?> finalStream = new (objectInstance);
         return finalStream; 

--- a/aad/stream_implementer.bal
+++ b/aad/stream_implementer.bal
@@ -49,11 +49,12 @@ class UserStream {
             self.index += 1;
             return singleRecord;
         }
+        return;
     }
 
     isolated function fetchRecordsInitial() returns User[]|error {
         http:Response response = check self.httpClient->get(self.path);
-        map<json>|string? handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         return check self.getAndConvertToUserArray(response);
     }
     
@@ -107,11 +108,12 @@ class GroupStream {
             self.index += 1;
             return singleRecord;
         }
+        return;
     }
 
     isolated function fetchRecordsInitial() returns Group[]|error {
         http:Response response = check self.httpClient->get(self.path);
-        map<json>|string? handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         return check self.getAndConvertToGroupArray(response);
     }
     
@@ -165,11 +167,12 @@ class PermissionGrantStream {
             self.index += 1;
             return singleRecord;
         }
+        return;
     }
 
     isolated function fetchRecordsInitial() returns PermissionGrant[]|error {
         http:Response response = check self.httpClient->get(self.path);
-        map<json>|string? handledResponse = check handleResponse(response);
+        _ = check handleResponse(response);
         return check self.getAndConvertToGrantArray(response);
     }
     

--- a/aad/tests/test.bal
+++ b/aad/tests/test.bal
@@ -135,13 +135,13 @@ function testUpdateUser() {
     enable: true,
     dependsOn: [testGetUser]
 }
-function testListUsers() {
+function testListUsers() returns error? {
     log:printInfo("client->listUsers()");
     runtime:sleep(2);
 
     stream<User,error?>|error userStream = aadClient->listUsers();
     if (userStream is stream<User,error?>) {
-        error? e = userStream.forEach(isolated function (User item) {
+        _ = check userStream.forEach(isolated function (User item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -154,7 +154,7 @@ function testListUsers() {
     enable: true,
     dependsOn: [testGetUser]
 }
-function testListUsersQueryParams() {
+function testListUsersQueryParams() returns error? {
     log:printInfo("client->listUsersWithParams()");
     runtime:sleep(2);
 
@@ -162,7 +162,7 @@ function testListUsersQueryParams() {
 
     stream<User,error?>|error userStream = aadClient->listUsers(params);
     if (userStream is stream<User,error?>) {
-        error? e = userStream.forEach(isolated function (User item) {
+        _ = check userStream.forEach(isolated function (User item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -243,7 +243,7 @@ function testUpdateGroup() {
 @test:Config {
     enable: true
 }
-function testListGroups() {
+function testListGroups() returns error? {
     log:printInfo("client->listGroups()");
     runtime:sleep(2);
 
@@ -251,7 +251,7 @@ function testListGroups() {
 
     stream<Group,error?>|error groupStream = aadClient->listGroups(query);
     if (groupStream is stream<Group,error?>) {
-        error? e = groupStream.forEach(isolated function (Group item) {
+        _ = check groupStream.forEach(isolated function (Group item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -283,7 +283,7 @@ function testRenewGroup() {
     enable: true,
     dependsOn: [testCreateGroup]
 }
-function testListParentGroups() { //test this for groups and users
+function testListParentGroups() returns error? { //test this for groups and users
     log:printInfo("client->listParentGroups()");
     runtime:sleep(2);
 
@@ -291,7 +291,7 @@ function testListParentGroups() { //test this for groups and users
 
     stream<Group,error?>|error groupStream = aadClient->listParentGroups("group", groupId);
     if (groupStream is stream<Group,error?>) {
-        error? e = groupStream.forEach(isolated function (Group item) {
+        _ = check groupStream.forEach(isolated function (Group item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -304,7 +304,7 @@ function testListParentGroups() { //test this for groups and users
     enable: true,
     dependsOn: [testCreateGroup]
 }
-function testListTransitiveParentGroups() { //test this for groups and users
+function testListTransitiveParentGroups() returns error? { //test this for groups and users
     log:printInfo("client->listParentGroups()");
     runtime:sleep(2);
 
@@ -312,7 +312,7 @@ function testListTransitiveParentGroups() { //test this for groups and users
 
     stream<Group,error?>|error groupStream = aadClient->listTransitiveParentGroups("group", groupId);
     if (groupStream is stream<Group,error?>) {
-        error? e = groupStream.forEach(isolated function (Group item) {
+        _ = check groupStream.forEach(isolated function (Group item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -345,7 +345,7 @@ function testAddMemberToGroup() {
     enable: true,
     dependsOn: [testAddMemberToGroup, testCreateGroup]
 }
-function testListMembers() {
+function testListMembers() returns error? {
     log:printInfo("client->listGroupMembers()");
     runtime:sleep(2);
 
@@ -353,7 +353,7 @@ function testListMembers() {
 
     stream<User,error?>|error groupStream = aadClient->listGroupMembers(groupId);
     if (groupStream is stream<User,error?>) {
-        error? e = groupStream.forEach(isolated function (User item) {
+        _ = check groupStream.forEach(isolated function (User item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -366,7 +366,7 @@ function testListMembers() {
     enable: true,
     dependsOn: [testAddMemberToGroup, testCreateGroup]
 }
-function testListTransitiveMembers() {
+function testListTransitiveMembers() returns error? {
     log:printInfo("client->listTransitiveGroupMembers()");
     runtime:sleep(2); 
 
@@ -374,7 +374,7 @@ function testListTransitiveMembers() {
 
     stream<User,error?>|error groupStream = aadClient->listTransitiveGroupMembers(groupId);
     if (groupStream is stream<User,error?>) {
-        error? e = groupStream.forEach(isolated function (User item) {
+        _ = check groupStream.forEach(isolated function (User item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -427,7 +427,7 @@ function testAddOwnerToGroup() {
     enable: true,
     dependsOn: [testAddOwnerToGroup, testCreateGroup]
 }
-function testListOwners() {
+function testListOwners() returns error? {
     log:printInfo("client->listGroupOwners()");
     runtime:sleep(2);
 
@@ -435,7 +435,7 @@ function testListOwners() {
 
     stream<User,error?>|error groupStream = aadClient->listGroupOwners(groupId);
     if (groupStream is stream<User,error?>) {
-        error? e = groupStream.forEach(isolated function (User item) {
+        _ = check groupStream.forEach(isolated function (User item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -468,7 +468,7 @@ function testRemoveOwner() {
     enable: true,
     dependsOn: [testCreateGroup]
 }
-function testListPermissionGrants() {
+function testListPermissionGrants() returns error? {
     log:printInfo("client->listPermissionGrants()");
     runtime:sleep(2);
 
@@ -476,7 +476,7 @@ function testListPermissionGrants() {
 
     stream<PermissionGrant, error?>|error grantStream = aadClient->listPermissionGrants(groupId);
     if (grantStream is stream<PermissionGrant, error?>) {
-        error? e = grantStream.forEach(isolated function (PermissionGrant item) {
+        _ = check grantStream.forEach(isolated function (PermissionGrant item) {
             log:printInfo(item.toString());
         });    
     } else {
@@ -486,7 +486,7 @@ function testListPermissionGrants() {
 }
 
 @test:AfterSuite {}
-function testDeleteUserAndGroup() {
+function testDeleteUserAndGroup() returns error? {
     runtime:sleep(2);
 
     string userId = newUserId;
@@ -501,7 +501,7 @@ function testDeleteUserAndGroup() {
     }
 
     log:printInfo("client->deleteGroup()");
-    error? groupDeleteResult = aadClient->deleteGroup(groupId);
+    _ = check aadClient->deleteGroup(groupId);
     if (userDeleteResult is ()) {
         log:printInfo("Sucessfully deleted group");
     } else {


### PR DESCRIPTION
# Description

fix build warning issues.


```
Compiling source
        ballerinax/azure.ad:2.0.0
WARNING [client.bal:(256:9,256:75)] unused variable 'handledResponse'
WARNING [client.bal:(307:9,307:75)] unused variable 'handledResponse'
WARNING [client.bal:(329:9,329:75)] unused variable 'handledResponse'
WARNING [client.bal:(380:9,380:75)] unused variable 'handledResponse'
WARNING [client.bal:(417:9,417:75)] unused variable 'handledResponse'
WARNING [stream_implementer.bal:(38:45,38:76)] this function should explicitly return a value
WARNING [stream_implementer.bal:(56:9,56:76)] unused variable 'handledResponse'
WARNING [stream_implementer.bal:(96:45,96:77)] this function should explicitly return a value
WARNING [stream_implementer.bal:(114:9,114:76)] unused variable 'handledResponse'
WARNING [stream_implementer.bal:(154:45,154:87)] this function should explicitly return a value
WARNING [stream_implementer.bal:(172:9,172:76)] unused variable 'handledResponse'
WARNING [tests/test.bal:(144:9,146:12)] unused variable 'e'
WARNING [tests/test.bal:(165:9,167:12)] unused variable 'e'
WARNING [tests/test.bal:(254:9,256:12)] unused variable 'e'
WARNING [tests/test.bal:(294:9,296:12)] unused variable 'e'
WARNING [tests/test.bal:(315:9,317:12)] unused variable 'e'
WARNING [tests/test.bal:(356:9,358:12)] unused variable 'e'
WARNING [tests/test.bal:(377:9,379:12)] unused variable 'e'
WARNING [tests/test.bal:(438:9,440:12)] unused variable 'e'
WARNING [tests/test.bal:(479:9,481:12)] unused variable 'e'
WARNING [tests/test.bal:(504:5,504:64)] unused variable 'groupDeleteResult'
```

One line release note: 
- fix build warning issues

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: slbeta6rc1
* Operating System: ubuntu
* Java SDK: Java11

# Checklist:

### Security checks
 - [X] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [X] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
