### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/build-with-bal-test-native.yml
+++ b/.github/workflows/build-with-bal-test-native.yml
@@ -32,7 +32,7 @@ jobs:
                 version: latest
 
             - name: Run Ballerina tests using the native executable
-              run: bal test --native ./aad
+              run: bal test --graalvm ./aad
               env:
                 REFRESH_URL: ${{ secrets.REFRESH_URL }}
                 REFRESH_TOKEN: ${{ secrets.REFRESH_TOKEN }}


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531